### PR TITLE
move openssl to dev-dependencies

### DIFF
--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -22,8 +22,8 @@ tracing = { version = "0.1", features = ["log", "attributes"] }
 tracing-futures = "0.2"
 http = "0.2"
 prost = "0.8"
-openssl = "0.10.34"
 
 [dev-dependencies]
 shared-proto = { path = "../shared_proto" }
 tests = { path = "../tests" }
+openssl = "0.10.34"


### PR DESCRIPTION
Move `openssl` crate to dev-dependencis so that it does not introduce an unnecessary OpenSSL dependency for projects that do not need or want it; for example, projects that use RustTLS over OpenSSL.

Upstream PR: https://github.com/TrueLayer/ginepro/pull/21